### PR TITLE
I've integrated multi-model LLM support and a model selection framework.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,7 +36,7 @@ ENCRYPTION_KEY_DERIVATION=PBKDF2
 # =============================================================================
 # CORE API KEYS (Required)
 # =============================================================================
-# Google Gemini API Key (primary LLM)
+# Google Gemini API Key (used as a primary LLM, see MODELS_CONFIG_JSON for full control)
 API_KEY=YOUR_GEMINI_API_KEY
 
 # Tavily API Key (for web search tool)
@@ -50,6 +50,9 @@ OPENAI_API_KEY=your_openai_api_key_here
 OPENAI_MODEL=gpt-4
 OPENAI_TEMPERATURE=0.7
 OPENAI_MAX_TOKENS=2048
+
+# Anthropic API Key
+ANTHROPIC_API_KEY=YOUR_ANTHROPIC_API_KEY
 
 # ElevenLabs API Key (for Text-to-Speech)
 ELEVENLABS_API_KEY=YOUR_ELEVENLABS_API_KEY
@@ -82,10 +85,25 @@ NEWS_API_KEY=YOUR_NEWSAPI_ORG_KEY
 OPENWEATHER_API_KEY=YOUR_OPENWEATHERMAP_API_KEY
 
 # =============================================================================
+# MULTI-MODEL LLM CONFIGURATION (Optional)
+# =============================================================================
+# Define available LLMs and the default model for the conversational agent.
+# If not set, system defaults (including Gemini, OpenAI, Anthropic) will be used.
+# Ensure corresponding API keys (GEMINI_API_KEY, OPENAI_API_KEY, ANTHROPIC_API_KEY) are set.
+# MODELS_CONFIG_JSON='{
+#   "available_models": [
+#     {"model_id": "gemini-1.5-pro-latest", "provider": "google", "api_key_env_var": "GEMINI_API_KEY"},
+#     {"model_id": "gpt-4o", "provider": "openai", "api_key_env_var": "OPENAI_API_KEY"},
+#     {"model_id": "claude-3-haiku-20240307", "provider": "anthropic", "api_key_env_var": "ANTHROPIC_API_KEY"}
+#   ],
+#   "default_model_id": "gemini-1.5-pro-latest"
+# }'
+
+# =============================================================================
 # LANGGRAPH SPECIFIC SETTINGS
 # =============================================================================
 # Model Configuration
-MODEL_NAME=gemini-2.0-flash
+# MODEL_NAME=gemini-2.0-flash (This can act as a fallback default if not specified in MODELS_CONFIG_JSON)
 TEMPERATURE=0.7
 
 # Graph execution settings

--- a/README.md
+++ b/README.md
@@ -214,9 +214,26 @@ NEWS_API_KEY="SUA_CHAVE_API_NEWSAPI"
 # OpenWeatherMap API Key (for the get_weather_info tool)
 OPENWEATHER_API_KEY="SUA_CHAVE_API_OPENWEATHERMAP"
 
+# --- Optional API Keys for Content Creation & Other Tools ---
+# ElevenLabs API Key (for Text-to-Speech)
+ELEVENLABS_API_KEY="SUA_CHAVE_API_ELEVENLABS"
+
+# OpenAI API Key (for GPT models)
+OPENAI_API_KEY="SUA_CHAVE_API_OPENAI"
+
+# Anthropic API Key (for Claude models)
+ANTHROPIC_API_KEY="SUA_CHAVE_API_ANTHROPIC"
+
+# OpenAI DALL-E API Key (for DALL-E image generation)
+DALLE_API_KEY="SUA_CHAVE_API_OPENAI_PARA_DALLE"
+# ... (rest of optional keys remain the same)
+
 # --- Model Configuration (Optional - Defaults provided) ---
-# MODEL_NAME="gemini-2.0-flash"
+# MODEL_NAME="gemini-2.0-flash" (Legacy - see new section on Multi-LLM Support)
 # TEMPERATURE="0.7"
+#
+# Para configuração avançada de múltiplos modelos (Google, OpenAI, Anthropic),
+# veja a variável de ambiente MODELS_CONFIG_JSON na seção "Suporte a Múltiplos Modelos de Linguagem (LLM)".
 
 # --- Persona Configuration (Optional - Defaults to Don Corleone) ---
 # PERSONA="Don Corleone"
@@ -230,6 +247,42 @@ OPENWEATHER_API_KEY="SUA_CHAVE_API_OPENWEATHERMAP"
    **Importante:** Substitua `"SUA_CHAVE_API_..."` pelos seus valores reais.
 
 ## 🖥️ Uso
+
+## 🤖 Suporte a Múltiplos Modelos de Linguagem (LLM)
+
+O agente conversacional principal agora pode utilizar modelos de linguagem de diferentes provedores, incluindo:
+- Google (modelos Gemini)
+- OpenAI (modelos GPT, como GPT-4o, GPT-3.5-turbo)
+- Anthropic (modelos Claude, como Claude 3 Haiku, Sonnet, Opus)
+
+Esta flexibilidade é gerenciada pelo `ModelManager` e `ModelSelector` internos, que escolhem um modelo apropriado com base na configuração e, futuramente, nos requisitos da tarefa.
+
+### Configurando Modelos LLM
+
+1.  **API Keys**: Certifique-se de que as chaves de API para os provedores desejados estão configuradas no seu arquivo `.env`:
+    *   `API_KEY` ou `GEMINI_API_KEY` para Google Gemini.
+    *   `OPENAI_API_KEY` para modelos OpenAI.
+    *   `ANTHROPIC_API_KEY` para modelos Anthropic.
+
+2.  **Seleção de Modelos (`MODELS_CONFIG_JSON`)**:
+    Você pode controlar quais modelos estão disponíveis para o agente e qual é o modelo padrão definindo a variável de ambiente `MODELS_CONFIG_JSON`. Esta variável aceita uma string JSON com a seguinte estrutura:
+
+    ```json
+    {
+      "available_models": [
+        {"model_id": "gemini-1.5-pro-latest", "provider": "google", "api_key_env_var": "GEMINI_API_KEY"},
+        {"model_id": "gpt-4o", "provider": "openai", "api_key_env_var": "OPENAI_API_KEY"},
+        {"model_id": "claude-3-haiku-20240307", "provider": "anthropic", "api_key_env_var": "ANTHROPIC_API_KEY"}
+      ],
+      "default_model_id": "gemini-1.5-pro-latest"
+    }
+    ```
+    - `available_models`: Uma lista dos modelos que o sistema pode usar. Especifique o `model_id` (conforme nomeado pelo provedor), `provider` ("google", "openai", ou "anthropic"), e `api_key_env_var` (o nome da variável no `.env` que contém a chave para este modelo).
+    - `default_model_id`: O `model_id` do modelo que será usado por padrão se nenhum outro critério específico for aplicado.
+
+    Se `MODELS_CONFIG_JSON` não for definido, o sistema utilizará uma lista padrão de modelos pré-configurados (atualmente incluindo Gemini, GPT-4o, e Claude 3 Haiku).
+
+O sistema seleciona automaticamente um modelo da lista de disponíveis. O antigo método de usar apenas `MODEL_NAME` no `.env` para definir o modelo do agente foi substituído por este sistema mais robusto. `MODEL_NAME` pode ainda influenciar um fallback se `MODELS_CONFIG_JSON` não estiver definido.
 
 ### Método 1: Usando o CLI do LangGraph
 
@@ -390,11 +443,10 @@ Quais são suas funcionalidades?
 
 ### Alterando o Modelo
 
-Você pode alterar o modelo usado adicionando a seguinte linha ao seu arquivo `.env`:
+A seleção do modelo de linguagem principal para o agente agora é mais flexível e configurável através da variável de ambiente `MODELS_CONFIG_JSON`.
+Consulte a seção "🤖 Suporte a Múltiplos Modelos de Linguagem (LLM)" para detalhes completos sobre como definir os modelos disponíveis (Google Gemini, OpenAI GPT, Anthropic Claude) e o modelo padrão.
 
-```dotenv
-MODEL_NAME=gemini-2.0-pro
-```
+A antiga configuração `MODEL_NAME` no arquivo `.env` pode servir como um fallback caso `MODELS_CONFIG_JSON` não esteja definido ou não especifique um padrão.
 
 ### Alterando a Personalidade do Agente
 

--- a/ai_providers/__init__.py
+++ b/ai_providers/__init__.py
@@ -9,11 +9,13 @@ from .openai_provider import OpenAIProvider
 from .anthropic_provider import AnthropicProvider
 from .google_provider import GoogleProvider
 from .model_selector import ModelSelector, ModelPerformanceTracker
+from .adapters import AIModelLangChainAdapter # Added import
 
 __all__ = [
     'OpenAIProvider',
     'AnthropicProvider', 
     'GoogleProvider',
     'ModelSelector',
-    'ModelPerformanceTracker'
+    'ModelPerformanceTracker',
+    'AIModelLangChainAdapter' # Added to __all__
 ]

--- a/ai_providers/adapters.py
+++ b/ai_providers/adapters.py
@@ -1,0 +1,283 @@
+"""
+Adapter to make AIModel instances compatible with LangChain's BaseChatModel.
+"""
+import sys
+from pathlib import Path
+from typing import List, Optional, Any, Dict
+
+# Ensure the root directory is in sys.path for model_manager import
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from model_manager import AIModel # Assuming AIModel is in model_manager.py in root
+from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.messages import (
+    AIMessage,
+    BaseMessage,
+    HumanMessage,
+    SystemMessage,
+    ChatMessage, # Added for more comprehensive message type handling
+)
+from langchain_core.outputs import ChatGeneration, ChatResult
+from langchain_core.callbacks import CallbackManagerForLLMRun
+
+class AIModelLangChainAdapter(BaseChatModel):
+    """
+    Adapter to use an AIModel instance as a LangChain BaseChatModel.
+    """
+    ai_model: AIModel
+    system_prompt_override: Optional[str] = None
+
+    def __init__(self, ai_model: AIModel, system_prompt_override: Optional[str] = None):
+        super().__init__()
+        self.ai_model = ai_model
+        self.system_prompt_override = system_prompt_override
+
+    def _generate(
+        self,
+        messages: List[BaseMessage],
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        """
+        Generates a chat response using the wrapped AIModel.
+        """
+        system_message_str: Optional[str] = self.system_prompt_override
+        prompt_parts: List[str] = []
+
+        for message in messages:
+            if isinstance(message, SystemMessage):
+                # If an explicit system prompt override is given to constructor, it takes precedence.
+                # Otherwise, the SystemMessage from the list is used.
+                # If multiple SystemMessages, the last one is used (or combined if preferred, here using last).
+                if not self.system_prompt_override:
+                    system_message_str = message.content
+            elif isinstance(message, HumanMessage):
+                prompt_parts.append(f"Human: {message.content}")
+            elif isinstance(message, AIMessage):
+                prompt_parts.append(f"AI: {message.content}")
+            elif isinstance(message, ChatMessage): # Handle generic ChatMessage
+                prompt_parts.append(f"{message.role}: {message.content}")
+            else: # Fallback for other message types
+                prompt_parts.append(message.content)
+        
+        prompt_str = "\n".join(prompt_parts)
+
+        # Prepare arguments for ai_model.predict
+        predict_kwargs = kwargs.copy()
+        if system_message_str:
+            predict_kwargs['system_message'] = system_message_str
+        if stop:
+            predict_kwargs['stop'] = stop
+        
+        # Assuming ai_model.predict can handle a 'system_message' kwarg.
+        # If not, this part would need adjustment based on AIModel's actual interface.
+        try:
+            response_text = self.ai_model.predict(prompt_str, **predict_kwargs)
+        except TypeError as e:
+            # This might happen if 'system_message' or 'stop' is not an expected kwarg
+            # by the underlying AIModel's predict method.
+            # We might need to log this and try without them or adjust AIModel interface.
+            if 'system_message' in str(e) and 'system_message' in predict_kwargs:
+                del predict_kwargs['system_message']
+            if 'stop' in str(e) and 'stop' in predict_kwargs:
+                del predict_kwargs['stop']
+            # Retry predict call with potentially modified kwargs
+            response_text = self.ai_model.predict(prompt_str, **predict_kwargs)
+
+
+        ai_message = AIMessage(content=response_text)
+        return ChatResult(generations=[ChatGeneration(message=ai_message)])
+
+    async def _agenerate(
+        self,
+        messages: List[BaseMessage],
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        """
+        Asynchronously generates a chat response using the wrapped AIModel.
+        """
+        system_message_str: Optional[str] = self.system_prompt_override
+        prompt_parts: List[str] = []
+
+        for message in messages:
+            if isinstance(message, SystemMessage):
+                if not self.system_prompt_override:
+                    system_message_str = message.content
+            elif isinstance(message, HumanMessage):
+                prompt_parts.append(f"Human: {message.content}")
+            elif isinstance(message, AIMessage):
+                prompt_parts.append(f"AI: {message.content}")
+            elif isinstance(message, ChatMessage):
+                prompt_parts.append(f"{message.role}: {message.content}")
+            else:
+                prompt_parts.append(message.content)
+
+        prompt_str = "\n".join(prompt_parts)
+        
+        predict_kwargs = kwargs.copy()
+        if system_message_str:
+            predict_kwargs['system_message'] = system_message_str
+        if stop:
+            predict_kwargs['stop'] = stop
+
+        # Assuming ai_model.apredict exists and handles similar kwargs
+        try:
+            response_text = await self.ai_model.apredict(prompt_str, **predict_kwargs)
+        except TypeError as e:
+            if 'system_message' in str(e) and 'system_message' in predict_kwargs:
+                del predict_kwargs['system_message']
+            if 'stop' in str(e) and 'stop' in predict_kwargs:
+                del predict_kwargs['stop']
+            response_text = await self.ai_model.apredict(prompt_str, **predict_kwargs)
+
+
+        ai_message = AIMessage(content=response_text)
+        return ChatResult(generations=[ChatGeneration(message=ai_message)])
+
+    @property
+    def _llm_type(self) -> str:
+        """Return type of LLM."""
+        return "aimodel_langchain_adapter"
+
+    # For Langchain compatibility, it's good practice to expose some model parameters
+    # if the underlying AIModel has them.
+    @property
+    def model_id(self) -> str:
+        return self.ai_model.model_id
+    
+    @property
+    def provider(self) -> str:
+        return self.ai_model.provider
+
+    # If your AIModel has identifiable kwargs, you can expose them.
+    # This is important for things like LCEL and runnables.
+    @property
+    def lc_serializable(self) -> bool:
+        return True # Mark that this class can be serialized by LangChain
+
+    def get_identifying_params(self) -> Dict[str, Any]:
+        """
+        Get the identifying parameters.
+        """
+        return {
+            "model_id": self.ai_model.model_id,
+            "provider": self.ai_model.provider,
+            "system_prompt_override": self.system_prompt_override,
+            **(self.ai_model.params if hasattr(self.ai_model, 'params') else {})
+        }
+
+    # BaseChatModel requires this if you don't implement _stream or _astream
+    def _stream(
+        self,
+        messages: List[BaseMessage],
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> None: # Actually Iterator[ChatGenerationChunk]
+        raise NotImplementedError("Streaming is not yet implemented for this adapter.")
+
+    async def _astream(
+        self,
+        messages: List[BaseMessage],
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> None: # Actually AsyncIterator[ChatGenerationChunk]
+        raise NotImplementedError("Async streaming is not yet implemented for this adapter.")
+
+if __name__ == '__main__':
+    # This is a placeholder for testing.
+    # To run this, you'd need a concrete AIModel implementation and LangChain installed.
+    
+    # Example of a dummy AIModel for testing
+    class DummyAIModel(AIModel):
+        def __init__(self, model_id: str, provider: str, params: Optional[Dict[str, Any]] = None):
+            super().__init__(model_id, provider, params=params)
+
+        def predict(self, prompt: str, **kwargs) -> Any:
+            print(f"DummyAIModel received prompt: {prompt}")
+            print(f"DummyAIModel received kwargs: {kwargs}")
+            sys_msg = kwargs.get('system_message', 'No system message')
+            return f"Response from {self.model_id} to '{prompt}' with system message '{sys_msg}'"
+
+        async def apredict(self, prompt: str, **kwargs) -> Any:
+            print(f"DummyAIModel (async) received prompt: {prompt}")
+            print(f"DummyAIModel (async) received kwargs: {kwargs}")
+            sys_msg = kwargs.get('system_message', 'No system message')
+            return f"Async response from {self.model_id} to '{prompt}' with system message '{sys_msg}'"
+
+    print("Testing AIModelLangChainAdapter...")
+    dummy_model = DummyAIModel(model_id="dummy-model-001", provider="dummy_provider", params={"temperature": 0.5})
+    adapter = AIModelLangChainAdapter(ai_model=dummy_model, system_prompt_override="Be a helpful assistant.")
+
+    # Test _generate
+    print("\n--- Testing _generate ---")
+    human_message = HumanMessage(content="Hello, how are you?")
+    # System message in list, but constructor override takes precedence
+    system_message_in_list = SystemMessage(content="This should be ignored.") 
+    chat_result = adapter.generate([[human_message, system_message_in_list]], stop=["\nHuman:"])
+    
+    if chat_result.generations:
+        response_message = chat_result.generations[0].message
+        print(f"Adapter response: {response_message.content}")
+        print(f"Adapter response type: {type(response_message)}")
+    else:
+        print("No generations in chat_result.")
+    
+    # Test without system_prompt_override to use the one from messages
+    adapter_no_override = AIModelLangChainAdapter(ai_model=dummy_model)
+    print("\n--- Testing _generate with system message from list ---")
+    system_message_from_list = SystemMessage(content="Be a pirate.")
+    chat_result_pirate = adapter_no_override.generate([[human_message, system_message_from_list]])
+    if chat_result_pirate.generations:
+        print(f"Adapter response (pirate): {chat_result_pirate.generations[0].message.content}")
+
+    # Test identifying params
+    print("\n--- Testing identifying_params ---")
+    print(adapter.get_identifying_params())
+    
+    # Test LLM type
+    print("\n--- Testing _llm_type ---")
+    print(adapter._llm_type)
+
+    # Test async generate (basic)
+    import asyncio
+    async def test_async():
+        print("\n--- Testing _agenerate ---")
+        chat_result_async = await adapter.agenerate([[human_message]])
+        if chat_result_async.generations:
+            response_message_async = chat_result_async.generations[0].message
+            print(f"Adapter async response: {response_message_async.content}")
+    
+    asyncio.run(test_async())
+
+    print("\nAdapter tests complete.")
+    # Note: The _stream and _astream methods are not implemented and will raise NotImplementedError if called.
+    # LangChain's BaseChatModel.generate will call _generate if _agenerate is not overridden for async calls.
+    # However, for true async behavior, _agenerate should be used.
+    # The current BaseChatModel structure prefers _agenerate if available.
+    # I've added a basic _agenerate implementation.
+    # For full LCEL compatibility, things like batching (_generate with List[List[BaseMessage]]) might be needed.
+    # Also, the `params` from AIModel are now included in `get_identifying_params`.
+    # Added `lc_serializable = True` and `get_identifying_params()` for better LangChain integration.
+    # Added ChatMessage handling.
+    # Added basic error handling in _generate and _agenerate for missing kwargs in AIModel.predict/apredict.
+    
+    # To make this test runnable, ensure model_manager.py with AIModel is in the parent directory
+    # and langchain_core is installed.
+    # Example:
+    # model_manager.py content:
+    # class AIModel(ABC): ... (as defined in previous tasks)
+    # Then run: python ai_providers/adapters.py
+    # (This test structure assumes direct execution for demonstration)
+
+    # The current implementation of _generate and _agenerate creates a single prompt string.
+    # For models that support a list of messages directly (like OpenAI chat models),
+    # it would be more appropriate to pass the messages list if self.ai_model can handle it.
+    # This adapter assumes self.ai_model.predict/apredict takes a single string prompt.
+    # If AIModel evolves to accept message lists, this adapter should be updated.
+
+```

--- a/core/config.py
+++ b/core/config.py
@@ -269,6 +269,7 @@ class ModelsConfig:
             self.available_models = [
                 ModelDetail(model_id="gemini-1.5-pro", provider="google", api_key_env_var="GEMINI_API_KEY"),
                 ModelDetail(model_id="gpt-4o", provider="openai", api_key_env_var="OPENAI_API_KEY"),
+                ModelDetail(model_id="claude-3-haiku-20240307", provider="anthropic", api_key_env_var="ANTHROPIC_API_KEY"),
                 # Example for a local model (actual implementation would require more setup)
                 # ModelDetail(model_id="llama3-8b-local", provider="local", parameters={"path": "/models/llama3-8b"})
             ]


### PR DESCRIPTION
This means I can now use LLMs from Google, OpenAI, and Anthropic, making me more flexible.

Here's a summary of the changes:
- I updated `core/config.py` (`ModelsConfig`) to manage a list of available models and a default model. You can configure this using the `MODELS_CONFIG_JSON` environment variable. I've included default models if you don't set it.
- I refactored `ai_providers/model_selector.py` (`ModelSelector`) so it can dynamically load model capabilities from the `ModelManager` instead of relying on hardcoded values.
- I created `ai_providers/adapters.py` with `AIModelLangChainAdapter`. This helps make `AIModel` provider instances (like OpenAI, Anthropic, and Google) work with the LangChain `BaseChatModel` interface I use.
- I modified `agent.py` (`create_agent`) so I can use `ModelSelector` to choose a model and then use the `AIModelLangChainAdapter` to pass the selected model to `SimpleAgent`.
- I verified that `OpenAIProvider` and `AnthropicProvider` are correctly set up by `ModelManager`.
- I added a temporary test function (`test_multi_provider_agent`) to `langgraph-101.py` so you can quickly check the multi-provider integration.
- I updated `README.md` and `.env.example` to document these new multi-model capabilities, how to configure API keys (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`), and how to use `MODELS_CONFIG_JSON`.

Now I can dynamically select and use different LLMs based on your configuration, which makes me more adaptable.